### PR TITLE
Created a checkbox in the settings for not showing a message if the sync fails

### DIFF
--- a/src/OutlookGoogleCalendarSync/MainForm.Designer.cs
+++ b/src/OutlookGoogleCalendarSync/MainForm.Designer.cs
@@ -148,6 +148,7 @@
             this.cbLoggingLevel = new System.Windows.Forms.ComboBox();
             this.cbStartOnStartup = new System.Windows.Forms.CheckBox();
             this.cbShowBubbleTooltips = new System.Windows.Forms.CheckBox();
+            this.cbShowFailMessage = new System.Windows.Forms.CheckBox();
             this.cbMinimiseToTray = new System.Windows.Forms.CheckBox();
             this.cbStartInTray = new System.Windows.Forms.CheckBox();
             this.cbCreateFiles = new System.Windows.Forms.CheckBox();
@@ -1448,6 +1449,7 @@
             this.tabAppBehaviour.Controls.Add(this.cbLoggingLevel);
             this.tabAppBehaviour.Controls.Add(this.cbStartOnStartup);
             this.tabAppBehaviour.Controls.Add(this.cbShowBubbleTooltips);
+            this.tabAppBehaviour.Controls.Add(this.cbShowFailMessage);
             this.tabAppBehaviour.Controls.Add(this.cbMinimiseToTray);
             this.tabAppBehaviour.Controls.Add(this.cbStartInTray);
             this.tabAppBehaviour.Controls.Add(this.cbCreateFiles);
@@ -1481,7 +1483,7 @@
             // cbPortable
             // 
             this.cbPortable.AutoSize = true;
-            this.cbPortable.Location = new System.Drawing.Point(16, 153);
+            this.cbPortable.Location = new System.Drawing.Point(16, 170);
             this.cbPortable.Name = "cbPortable";
             this.cbPortable.Size = new System.Drawing.Size(148, 17);
             this.cbPortable.TabIndex = 38;
@@ -1507,7 +1509,7 @@
             this.gbProxy.Controls.Add(this.label5);
             this.gbProxy.Font = new System.Drawing.Font("Arial Black", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.gbProxy.ForeColor = System.Drawing.SystemColors.MenuHighlight;
-            this.gbProxy.Location = new System.Drawing.Point(16, 225);
+            this.gbProxy.Location = new System.Drawing.Point(16, 242);
             this.gbProxy.Name = "gbProxy";
             this.gbProxy.Size = new System.Drawing.Size(364, 200);
             this.gbProxy.TabIndex = 37;
@@ -1681,7 +1683,7 @@
             // 
             this.btLogLocation.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btLogLocation.FlatStyle = System.Windows.Forms.FlatStyle.System;
-            this.btLogLocation.Location = new System.Drawing.Point(302, 193);
+            this.btLogLocation.Location = new System.Drawing.Point(302, 210);
             this.btLogLocation.Name = "btLogLocation";
             this.btLogLocation.Size = new System.Drawing.Size(80, 23);
             this.btLogLocation.TabIndex = 19;
@@ -1692,7 +1694,7 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(13, 198);
+            this.label3.Location = new System.Drawing.Point(13, 215);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(70, 13);
             this.label3.TabIndex = 18;
@@ -1714,7 +1716,7 @@
             "Fine",
             "Ultra-Fine",
             "All"});
-            this.cbLoggingLevel.Location = new System.Drawing.Point(86, 194);
+            this.cbLoggingLevel.Location = new System.Drawing.Point(86, 211);
             this.cbLoggingLevel.Name = "cbLoggingLevel";
             this.cbLoggingLevel.Size = new System.Drawing.Size(210, 21);
             this.cbLoggingLevel.TabIndex = 17;
@@ -1742,6 +1744,16 @@
             this.cbShowBubbleTooltips.UseVisualStyleBackColor = true;
             this.cbShowBubbleTooltips.CheckedChanged += new System.EventHandler(this.cbShowBubbleTooltipsCheckedChanged);
             // 
+            // cbShowFailMessage
+            // 
+            this.cbShowFailMessage.Location = new System.Drawing.Point(16, 152);
+            this.cbShowFailMessage.Name = "cbShowFailMessage";
+            this.cbShowFailMessage.Size = new System.Drawing.Size(259, 17);
+            this.cbShowFailMessage.TabIndex = 41;
+            this.cbShowFailMessage.Text = "Show message if sync fails";
+            this.cbShowFailMessage.UseVisualStyleBackColor = true;
+            this.cbShowFailMessage.CheckedChanged += new System.EventHandler(this.cbShowFailMessageCheckedChanged);
+            // 
             // cbMinimiseToTray
             // 
             this.cbMinimiseToTray.Location = new System.Drawing.Point(16, 98);
@@ -1764,7 +1776,7 @@
             // 
             // cbCreateFiles
             // 
-            this.cbCreateFiles.Location = new System.Drawing.Point(16, 171);
+            this.cbCreateFiles.Location = new System.Drawing.Point(16, 188);
             this.cbCreateFiles.Name = "cbCreateFiles";
             this.cbCreateFiles.Size = new System.Drawing.Size(235, 17);
             this.cbCreateFiles.TabIndex = 15;
@@ -2507,6 +2519,7 @@
         private System.Windows.Forms.ComboBox cbLoggingLevel;
         private System.Windows.Forms.CheckBox cbStartOnStartup;
         private System.Windows.Forms.CheckBox cbShowBubbleTooltips;
+        private System.Windows.Forms.CheckBox cbShowFailMessage;
         private System.Windows.Forms.CheckBox cbMinimiseToTray;
         private System.Windows.Forms.CheckBox cbStartInTray;
         private System.Windows.Forms.CheckBox cbCreateFiles;

--- a/src/OutlookGoogleCalendarSync/MainForm.cs
+++ b/src/OutlookGoogleCalendarSync/MainForm.cs
@@ -316,6 +316,7 @@ namespace OutlookGoogleCalendarSync {
             #endregion
             #region Application behaviour
             cbShowBubbleTooltips.Checked = Settings.Instance.ShowBubbleTooltipWhenSyncing;
+            cbShowFailMessage.Checked = Settings.Instance.ShowMessageWhenSyncFails;
             cbStartOnStartup.Checked = Settings.Instance.StartOnStartup;
             cbHideSplash.Checked = Settings.Instance.HideSplashScreen;
             cbStartInTray.Checked = Settings.Instance.StartInTray;
@@ -516,6 +517,11 @@ namespace OutlookGoogleCalendarSync {
             GoogleCalendar.Instance.GetCalendarSettings();
             while (!syncOk) {
                 if (failedAttempts > 0) {
+                    if (!Settings.Instance.ShowMessageWhenSyncFails)
+                    {
+                        log.Info("User doesn't want a message when syncing fails.");
+                        break;
+                    }
                     if (MessageBox.Show("The synchronisation failed - check the Sync tab for further details.\r\nDo you want to try again?", "Sync Failed",
                         MessageBoxButtons.YesNo, MessageBoxIcon.Exclamation) == System.Windows.Forms.DialogResult.No) 
                         break;
@@ -1627,6 +1633,10 @@ namespace OutlookGoogleCalendarSync {
 
         private void cbShowBubbleTooltipsCheckedChanged(object sender, System.EventArgs e) {
             Settings.Instance.ShowBubbleTooltipWhenSyncing = cbShowBubbleTooltips.Checked;
+        }
+
+        private void cbShowFailMessageCheckedChanged(object sender, System.EventArgs e) {
+            Settings.Instance.ShowMessageWhenSyncFails = cbShowFailMessage.Checked;
         }
 
         private void cbStartInTrayCheckedChanged(object sender, System.EventArgs e) {

--- a/src/OutlookGoogleCalendarSync/Settings.cs
+++ b/src/OutlookGoogleCalendarSync/Settings.cs
@@ -73,6 +73,7 @@ namespace OutlookGoogleCalendarSync {
             Obfuscation = new Obfuscate();
 
             ShowBubbleTooltipWhenSyncing = true;
+            ShowMessageWhenSyncFails = true;
             StartOnStartup = false;
             StartInTray = false;
             MinimiseToTray = false;
@@ -203,6 +204,7 @@ namespace OutlookGoogleCalendarSync {
         }
         
         [DataMember] public bool ShowBubbleTooltipWhenSyncing { get; set; }
+        [DataMember] public bool ShowMessageWhenSyncFails { get; set; }
         [DataMember] public bool StartOnStartup { get; set; }
         [DataMember] public bool StartInTray { get; set; }
         [DataMember] public bool MinimiseToTray { get; set; }
@@ -346,6 +348,7 @@ namespace OutlookGoogleCalendarSync {
         
             log.Info("APPLICATION BEHAVIOUR:-");
             log.Info("  ShowBubbleTooltipWhenSyncing: " + ShowBubbleTooltipWhenSyncing);
+            log.Info("  ShowMessageWhenSyncFails: " + ShowMessageWhenSyncFails);
             log.Info("  StartOnStartup: " + StartOnStartup);
             log.Info("  HideSplashScreen: " + ((Subscribed != DateTime.Parse("01-Jan-2000") || Donor) ? HideSplashScreen.ToString() : "N/A"));
             log.Info("  StartInTray: " + StartInTray);


### PR DESCRIPTION
It happens 2-3 times per day that the message pops up saying "The synchronisation failed - check the Sync tab for further details. Do you want to try again?". Looking at the log it says "GoogleApiRequestException: Not authorized", but without changing anything it works the next time.

Basically I created a checkbox in the settings that allows to disable the message popup (default is enabled), so I won't be annoyed by a message for a problem that I can't solve.

I thought that maybe other people have the same issue, so I created this pull request.