### PR TITLE
Issue 702

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs
+/src/.vs/OutlookGoogleCalendarSync/v15

--- a/src/OutlookGoogleCalendarSync/GoogleOgcs/GoogleCalendar.cs
+++ b/src/OutlookGoogleCalendarSync/GoogleOgcs/GoogleCalendar.cs
@@ -1093,7 +1093,7 @@ namespace OutlookGoogleCalendarSync.GoogleOgcs {
                                 log.Fine("This appointment was copied by the user. Incorrect match avoided.");
                                 return false;
                             } else {
-                                if (ai.Organizer != OutlookOgcs.Calendar.Instance.IOutlook.CurrentUserName()) {
+                                if (OutlookOgcs.Calendar.GetEventOrganizer(ai) != OutlookOgcs.Calendar.Instance.IOutlook.CurrentUserName()) {
                                     log.Fine("Organiser changed time of appointment.");
                                     CustomProperty.AddOutlookIDs(ref ev, ai); //update EntryID
                                     CustomProperty.Add(ref ev, CustomProperty.MetadataId.forceSave, "True");
@@ -1103,7 +1103,6 @@ namespace OutlookGoogleCalendarSync.GoogleOgcs {
                                     return false;
                                 }
                             }
-
                         } else {
                             log.Fine("EntryID has changed - invite accepted?");
                             if (SignaturesMatch(signature(ev), OutlookOgcs.Calendar.signature(ai))) {

--- a/src/OutlookGoogleCalendarSync/OutlookGoogleCalendarSync.csproj.user
+++ b/src/OutlookGoogleCalendarSync/OutlookGoogleCalendarSync.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <EnableSecurityDebugging>false</EnableSecurityDebugging>
+  </PropertyGroup>
+</Project>

--- a/src/OutlookGoogleCalendarSync/OutlookOgcs/OutlookCalendar.cs
+++ b/src/OutlookGoogleCalendarSync/OutlookOgcs/OutlookCalendar.cs
@@ -540,7 +540,7 @@ namespace OutlookGoogleCalendarSync.OutlookOgcs {
                             Boolean foundAttendee = false;
                             try {
                                 recipient = recipients[r];
-                                if (recipient.Name == ai.Organizer) continue;
+                                if (recipient.Name == GetEventOrganizer(ai)) continue;
 
                                 if (!recipient.Resolved) recipient.Resolve();
                                 String recipientSMTP = IOutlook.GetRecipientEmail(recipient);
@@ -577,7 +577,7 @@ namespace OutlookGoogleCalendarSync.OutlookOgcs {
                         }
                         foreach (EventAttendee gAttendee in addAttendees) {
                             GoogleOgcs.EventAttendee attendee = new GoogleOgcs.EventAttendee(gAttendee);
-                            if (attendee.DisplayName == ai.Organizer) continue; //Attendee in Google is owner in Outlook, so can't also be added as a recipient)
+                            if (attendee.DisplayName == GetEventOrganizer(ai)) continue; //Attendee in Google is owner in Outlook, so can't also be added as a recipient)
 
                             sb.AppendLine("Recipient added: " + (attendee.DisplayName ?? attendee.Email));
                             createRecipient(attendee, ref recipients);
@@ -1109,6 +1109,23 @@ namespace OutlookGoogleCalendarSync.OutlookOgcs {
             csv.Append(CustomProperty.Get(ai, CustomProperty.MetadataId.locallyCopied) ?? "");
 
             return csv.ToString();
+        }
+
+        /// <summary>
+        /// Get the organizer's name of the give event. 
+        /// In some cases Outlook fails to provide one (probably due to security issues). 
+        /// In this case null is returned
+        /// </summary>
+        /// <param name="ai"></param>
+        /// <returns></returns>
+        public static string GetEventOrganizer(AppointmentItem ai) {
+            try {
+                return ai.Organizer;
+            } catch (System.Exception exc) {
+                log.ErrorFormat("Couldn't get an organizer for event {0}", GetEventSummary(ai));
+                OGCSexception.Analyse(exc, true);
+                return null;
+            }
         }
 
         /// <summary>

--- a/src/OutlookGoogleCalendarSync/OutlookOgcs/OutlookNew.cs
+++ b/src/OutlookGoogleCalendarSync/OutlookOgcs/OutlookNew.cs
@@ -614,7 +614,7 @@ namespace OutlookGoogleCalendarSync.OutlookOgcs {
             String organiserTZname = null;
             String organiserTZid = null;
             try {
-                if (ai.Organizer != CurrentUserName()) {
+                if (Calendar.GetEventOrganizer(ai) != CurrentUserName()) {
                 log.Fine("Meeting organiser is someone else - checking their timezone.");
                     PropertyAccessor pa = null;
                     try {

--- a/src/OutlookGoogleCalendarSync/OutlookOgcs/OutlookNew.cs
+++ b/src/OutlookGoogleCalendarSync/OutlookOgcs/OutlookNew.cs
@@ -613,9 +613,9 @@ namespace OutlookGoogleCalendarSync.OutlookOgcs {
         public Event IANAtimezone_set(Event ev, AppointmentItem ai) {
             String organiserTZname = null;
             String organiserTZid = null;
-            if (ai.Organizer != CurrentUserName()) {
+            try {
+                if (ai.Organizer != CurrentUserName()) {
                 log.Fine("Meeting organiser is someone else - checking their timezone.");
-                try {
                     PropertyAccessor pa = null;
                     try {
                         pa = ai.PropertyAccessor;
@@ -636,14 +636,14 @@ namespace OutlookGoogleCalendarSync.OutlookOgcs {
                         if (tzi == null) log.Error("No timezone ID exists for organiser's timezone " + organiserTZname);
                         else organiserTZid = tzi.Id;
                     }
-                } catch (System.Exception ex) {
-                    Forms.Main.Instance.Console.Update(OutlookOgcs.Calendar.GetEventSummary(ai) +
-                        "<br/>Could not determine the organiser's timezone. Google Event may have incorrect time.", Console.Markup.warning);
-                    if (ex.Data.Contains("OGCS")) log.Warn(ex.Message);
-                    else OGCSexception.Analyse(ex);
-                    organiserTZname = null;
-                    organiserTZid = null;
                 }
+            } catch (System.Exception ex) {
+                Forms.Main.Instance.Console.Update(OutlookOgcs.Calendar.GetEventSummary(ai) +
+                    "<br/>Could not determine the organiser's timezone. Google Event may have incorrect time.", Console.Markup.warning);
+                if (ex.Data.Contains("OGCS")) log.Warn(ex.Message);
+                else OGCSexception.Analyse(ex);
+                organiserTZname = null;
+                organiserTZid = null;
             }
 
             try {


### PR DESCRIPTION
Fixing issue #702 . AppointmentItem.Organizer reading causes problems due to environment. Created a OutlookOgcs.Calendar.GetEventOrganizer() and replaced all readings of AppointmentItem.Organizer with calling this method.