### PR TITLE
Add support for Office Pro Plus 2021 Retail

### DIFF
--- a/src/OutlookGoogleCalendarSync/OutlookOgcs/OutlookFactory.cs
+++ b/src/OutlookGoogleCalendarSync/OutlookOgcs/OutlookFactory.cs
@@ -50,7 +50,8 @@ namespace OutlookGoogleCalendarSync.OutlookOgcs {
             Standard2019Volume = 31,
             Standard2021Volume = 32,
             ProPlus2019Volume = 33,
-            ProPlus2021Volume = 34
+            ProPlus2021Volume = 34,
+            ProPlus2021Retail = 35
         }
 
         private const Boolean testing2003 = false;


### PR DESCRIPTION
Fixes #1332.  Just needed the enum value for Office Pro Plus 2021 Retail (already had Volume).

Signed-off-by: Jon Stelly <967068+jonstelly@users.noreply.github.com>