### PR TITLE
Fix Classic Outlook recurring timezone drift

### DIFF
--- a/src/OutlookGoogleCalendarSync/Extensions/DateTime.cs
+++ b/src/OutlookGoogleCalendarSync/Extensions/DateTime.cs
@@ -121,23 +121,28 @@ namespace OutlookGoogleCalendarSync.Extensions {
         }
 
         /// <summary>
-        /// Returns the non-null Date or DateTime properties as a DateTime
+        /// Returns the non-null Date or DateTime properties as a DateTime.
+        /// For use with classic Outlook or where the user's Windows clock is relevant.
         /// </summary>
         /// <returns>DateTime</returns>
-        [Obsolete("[deprecated, use SafeDateTimeOffset()]")]
         public static System.DateTime SafeDateTime(this EventDateTime evDt) {
-            return SafeDateTimeOffset(evDt).DateTime;
+            if (evDt.DateTimeDateTimeOffset == null)
+                return System.DateTime.ParseExact(evDt.Date, "yyyy-MM-dd", CultureInfo.InvariantCulture).Date;
+            else
+                return evDt.DateTimeDateTimeOffset.Value.ToLocalTime().DateTime;
         }
 
         /// <summary>
-        /// Returns the non-null Date or DateTime properties as a DateTimeOffset
+        /// Returns the non-null Date or DateTime properties as a DateTimeOffset.
+        /// Retains cloud-native offset and timezone.
+        /// Use this for Cloud-to-Cloud synchronization (Google <-> Graph) where local system time is irrelevant.
         /// </summary>
         /// <returns>DateTimeOffset</returns>
         public static System.DateTimeOffset SafeDateTimeOffset(this EventDateTime evDt) {
             if (evDt.DateTimeDateTimeOffset == null)
                 return System.DateTimeOffset.ParseExact(evDt.Date, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
 
-            Int16 offset = TimezoneDB.GetUtcOffset(evDt.TimeZone);
+            Int16 offset = TimezoneDB.GetUtcOffset(evDt.TimeZone, evDt.DateTimeDateTimeOffset.Value.UtcDateTime);
             System.DateTimeOffset retDto = (DateTimeOffset)evDt.DateTimeDateTimeOffset;
             return retDto.ToOffset(TimeSpan.FromMinutes(offset));
         }

--- a/src/OutlookGoogleCalendarSync/Google/GoogleRecurrence.cs
+++ b/src/OutlookGoogleCalendarSync/Google/GoogleRecurrence.cs
@@ -299,7 +299,7 @@ namespace OutlookGoogleCalendarSync.Google {
             }
             log.Debug("Found " + googleExceptions.Count + " exceptions.");
             if (log.IsFineEnabled())
-                googleExceptions.ForEach(ge => log.Fine($"RecurringEventId:{ge.RecurringEventId}; Start:{(ge.Start == null ? "null" : ge.Start.SafeDateTimeOffset().ToString())};"));
+                googleExceptions.ForEach(ge => log.Fine($"RecurringEventId:{ge.RecurringEventId}; Start:{(ge.Start == null ? "null" : ge.Start.SafeDateTime().ToString())};"));
         }
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace OutlookGoogleCalendarSync.Google {
         /// <param name="originalInstanceDate">The date to search for</param>
         /// <returns></returns>
         public static Event GetGoogleInstance(String recurringEventId, System.DateTime originalInstanceDate) {
-            return googleExceptions.FirstOrDefault(g => g.RecurringEventId == recurringEventId && g.OriginalStartTime.SafeDateTimeOffset().Date == originalInstanceDate);
+            return googleExceptions.FirstOrDefault(g => g.RecurringEventId == recurringEventId && g.OriginalStartTime.SafeDateTime().Date == originalInstanceDate.Date);
         }
 
         /// <summary>

--- a/src/OutlookGoogleCalendarSync/Outlook/OutlookCalendar.cs
+++ b/src/OutlookGoogleCalendarSync/Outlook/OutlookCalendar.cs
@@ -611,8 +611,8 @@ namespace OutlookGoogleCalendarSync.Outlook {
             Boolean endChange = false;
             OgcsDateTimeOffset aiStart = new(ai.Start, aiAllDay);
             OgcsDateTimeOffset aiEnd = new(ai.End, aiAllDay);
-            System.DateTimeOffset evStartParsedDate = ev.Start.SafeDateTimeOffset();
-            System.DateTimeOffset evEndParsedDate = ev.End.SafeDateTimeOffset();
+            System.DateTime evStartParsedDate = ev.Start.SafeDateTime();
+            System.DateTime evEndParsedDate = ev.End.SafeDateTime();
             if (ev.AllDayEvent()) {
                 startChange = Sync.Engine.CompareAttribute("Start time", Sync.Direction.GoogleToOutlook, new OgcsDateTimeOffset(evStartParsedDate, true), aiStart, sb, ref itemModified);
                 endChange = Sync.Engine.CompareAttribute("End time", Sync.Direction.GoogleToOutlook, new OgcsDateTimeOffset(evEndParsedDate, true), aiEnd, sb, ref itemModified);
@@ -634,12 +634,12 @@ namespace OutlookGoogleCalendarSync.Outlook {
                         } else {
                             oPattern = (ai.RecurrenceState == OlRecurrenceState.olApptMaster) ? ai.GetRecurrencePattern() : null;
                             if (startChange) {
-                                oPattern.PatternStartDate = evStartParsedDate.DateTime;
-                                oPattern.StartTime = TimeZoneInfo.ConvertTime(evStartParsedDate.DateTime, TimeZoneInfo.FindSystemTimeZoneById(newStartTZ));
+                                oPattern.PatternStartDate = evStartParsedDate;
+                                oPattern.StartTime = TimeZoneInfo.ConvertTime(evStartParsedDate, TimeZoneInfo.FindSystemTimeZoneById(newStartTZ));
                             }
                             if (endChange) {
-                                oPattern.PatternEndDate = evEndParsedDate.DateTime;
-                                oPattern.EndTime = TimeZoneInfo.ConvertTime(evEndParsedDate.DateTime, TimeZoneInfo.FindSystemTimeZoneById(newEndTZ));
+                                oPattern.PatternEndDate = evEndParsedDate;
+                                oPattern.EndTime = TimeZoneInfo.ConvertTime(evEndParsedDate, TimeZoneInfo.FindSystemTimeZoneById(newEndTZ));
                             }
                         }
                     } else {

--- a/src/OutlookGoogleCalendarSync/TimezoneDB.cs
+++ b/src/OutlookGoogleCalendarSync/TimezoneDB.cs
@@ -192,7 +192,7 @@ namespace OutlookGoogleCalendarSync {
         /// </summary>
         /// <param name="IanaTimezone">eg "America/Vancouver"</param>
         /// <returns>The offset in minutes eg -7 hours as -420</returns>
-        public static Int16 GetUtcOffset(String IanaTimezone) {
+        public static Int16 GetUtcOffset(String IanaTimezone, DateTime? utcInstant = null) {
             Int16 utcOffset = 0;
             try {
                 NodaTime.IDateTimeZoneProvider tzProvider = NodaTime.DateTimeZoneProviders.Tzdb;
@@ -200,7 +200,7 @@ namespace OutlookGoogleCalendarSync {
                     log.Warn("Could not map IANA timezone '" + IanaTimezone + "' to UTC offset.");
                 } else {
                     NodaTime.DateTimeZone tz = tzProvider[IanaTimezone];
-                    NodaTime.Instant instant = NodaTime.Instant.FromDateTimeUtc(DateTime.UtcNow);
+                    NodaTime.Instant instant = NodaTime.Instant.FromDateTimeUtc(utcInstant ?? DateTime.UtcNow);
                     NodaTime.Offset offset = tz.GetUtcOffset(instant);
                     utcOffset = Convert.ToInt16(offset.Seconds / 60);
                 }


### PR DESCRIPTION
## Summary

- restore local wall-clock conversion for Google events entering Classic Outlook
- calculate IANA timezone offsets at the event instant instead of the current instant
- compare recurring Google exceptions using Classic Outlook local dates

## Root cause

Version 3.0.3 routes Classic Outlook recurrence paths through the cloud-native `DateTimeOffset` conversion. Recurring invitations can retain the organiser's timezone metadata, so repeatedly passing the series through merged profiles converts it again and progressively shifts its wall-clock time.

The offset helper also used the offset in effect when the sync ran, rather than the offset in effect on the event date, which produces an additional one-hour error across DST boundaries.

Fixes #2354.

## Validation

- restored all packages from `packages.config`
- built Debug and Release Any CPU with Visual Studio Build Tools 2026
- passed an executable-level Zurich winter regression: `19:00Z` -> `20:00 +01:00`
- passed an executable-level Central-organiser/Eastern-workstation regression: cloud value `14:30 -05:00`, Classic Outlook local wall clock `15:30`
- passed a controlled real-calendar recurring-event round trip through Google and both Classic Outlook calendars across the November DST boundary; intended wall-clock times remained stable and follow-up syncs converged to zero changes
- exercised the actual four one-way profile topology from #2354 with deletion protection enabled:
  - C -> A: 0 created, 0 deleted, 0 updated
  - F -> A: 0 eligible Outlook items because Google-originated Outlook items are Private; 0 created, 0 deleted, 0 updated
  - A -> C: Outlook 27 / Google 27; 0 created, 0 deleted, 0 updated
  - A -> F: Outlook 27 / Google 27; 0 created, 0 deleted, 0 updated
- restored the original automatic intervals and Outlook push monitoring; the first automatic C -> A cycle completed with 0 created, 0 deleted, and 0 updated
- confirmed that previously corrupted Google recurrence masters from the original failure can be propagated back by reverse profiles; those stale source records were removed before evaluating clean-data convergence
- `git diff --check`

The repository has no automated test project. The Visual Studio 2026 build required an explicit `Enumerable.Reverse(...)` call around the pre-existing `Program.cs:663` expression because the current compiler binds the array `Reverse()` call to a void span overload. That unrelated compatibility edit is not included in this PR.
