### PR TITLE
Add option to remove past events from destination calendar

### DIFF
--- a/src/OutlookGoogleCalendarSync/Forms/MainForm.Designer.cs
+++ b/src/OutlookGoogleCalendarSync/Forms/MainForm.Designer.cs
@@ -189,6 +189,7 @@
             this.cbMergeItems = new System.Windows.Forms.CheckBox();
             this.cbDisableDeletion = new System.Windows.Forms.CheckBox();
             this.cbConfirmOnDelete = new System.Windows.Forms.CheckBox();
+            this.cbRemovePastEvents = new System.Windows.Forms.CheckBox();
             this.howObfuscatePanel = new System.Windows.Forms.Panel();
             this.btCloseRegexRules = new System.Windows.Forms.Button();
             this.cbObfuscateDirection = new System.Windows.Forms.ComboBox();
@@ -2021,6 +2022,7 @@
             this.gbSyncOptions_How.Controls.Add(this.cbMergeItems);
             this.gbSyncOptions_How.Controls.Add(this.cbDisableDeletion);
             this.gbSyncOptions_How.Controls.Add(this.cbConfirmOnDelete);
+            this.gbSyncOptions_How.Controls.Add(this.cbRemovePastEvents);
             this.gbSyncOptions_How.Controls.Add(this.howObfuscatePanel);
             this.gbSyncOptions_How.Controls.Add(this.lDirection);
             this.gbSyncOptions_How.Font = new System.Drawing.Font("Arial Black", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -2273,7 +2275,19 @@
             this.cbConfirmOnDelete.Text = "Confirm deletions";
             this.cbConfirmOnDelete.UseVisualStyleBackColor = true;
             this.cbConfirmOnDelete.CheckedChanged += new System.EventHandler(this.cbConfirmOnDelete_CheckedChanged);
-            // 
+            //
+            // cbRemovePastEvents
+            //
+            this.cbRemovePastEvents.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.cbRemovePastEvents.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.cbRemovePastEvents.Location = new System.Drawing.Point(190, 67);
+            this.cbRemovePastEvents.Name = "cbRemovePastEvents";
+            this.cbRemovePastEvents.Size = new System.Drawing.Size(160, 17);
+            this.cbRemovePastEvents.TabIndex = 35;
+            this.cbRemovePastEvents.Text = "Remove past events";
+            this.cbRemovePastEvents.UseVisualStyleBackColor = true;
+            this.cbRemovePastEvents.CheckedChanged += new System.EventHandler(this.cbRemovePastEvents_CheckedChanged);
+            //
             // howObfuscatePanel
             // 
             this.howObfuscatePanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
@@ -4468,6 +4482,7 @@
         private System.Windows.Forms.CheckBox cbMergeItems;
         private System.Windows.Forms.CheckBox cbDisableDeletion;
         private System.Windows.Forms.CheckBox cbConfirmOnDelete;
+        private System.Windows.Forms.CheckBox cbRemovePastEvents;
         private System.Windows.Forms.Button btObfuscateRules;
         private System.Windows.Forms.GroupBox gbOutlook_ODate;
         private System.Windows.Forms.TextBox tbOutlookDateFormat;

--- a/src/OutlookGoogleCalendarSync/Forms/MainForm.cs
+++ b/src/OutlookGoogleCalendarSync/Forms/MainForm.cs
@@ -503,6 +503,8 @@ namespace OutlookGoogleCalendarSync.Forms {
                     cbDisableDeletion.Checked = profile.DisableDelete;
                     cbConfirmOnDelete.Enabled = !profile.DisableDelete;
                     cbConfirmOnDelete.Checked = profile.ConfirmOnDelete;
+                    cbRemovePastEvents.Checked = profile.RemovePastEvents;
+                    setRemovePastEventsAvailability(profile);
                     cbOfuscate.Checked = profile.Obfuscation.Enabled;
                     howObfuscatePanel.Visible = false;
 
@@ -2117,6 +2119,7 @@ namespace OutlookGoogleCalendarSync.Forms {
                 cbExcludeTentative.Visible = true;
                 cbExcludeOoO.Visible = true;
             }
+            setRemovePastEventsAvailability(ActiveCalendarProfile);
             cbAddAttendees_CheckedChanged(null, null);
             cbAddReminders_CheckedChanged(null, null);
             cbGoogleCalendars_SelectedIndexChanged(null, null);
@@ -2135,6 +2138,18 @@ namespace OutlookGoogleCalendarSync.Forms {
         private void cbDisableDeletion_CheckedChanged(object sender, System.EventArgs e) {
             ActiveCalendarProfile.DisableDelete = cbDisableDeletion.Checked;
             cbConfirmOnDelete.Enabled = !cbDisableDeletion.Checked;
+            setRemovePastEventsAvailability(ActiveCalendarProfile);
+        }
+
+        private void cbRemovePastEvents_CheckedChanged(object sender, System.EventArgs e) {
+            ActiveCalendarProfile.RemovePastEvents = cbRemovePastEvents.Checked;
+        }
+
+        /// <summary>"Remove past events" only applies to one-way profiles, and is unavailable while deletions are disabled.</summary>
+        private void setRemovePastEventsAvailability(SettingsStore.Calendar profile) {
+            Boolean oneWay = profile.SyncDirection.Id != Sync.Direction.Bidirectional.Id;
+            cbRemovePastEvents.Visible = oneWay;
+            cbRemovePastEvents.Enabled = oneWay && !profile.DisableDelete;
         }
 
         private void cbOfuscate_CheckedChanged(object sender, EventArgs e) {

--- a/src/OutlookGoogleCalendarSync/Google/GoogleCalendar.cs
+++ b/src/OutlookGoogleCalendarSync/Google/GoogleCalendar.cs
@@ -320,6 +320,41 @@ namespace OutlookGoogleCalendarSync.Google {
             return GetCalendarEntriesInRange(profile.SyncStart, profile.SyncEnd, false, recurringId);
         }
 
+        /// <summary>Get calendar Events that have fallen before the "days in the past" sync window, so are no longer touched by a normal sync</summary>
+        public List<Event> GetPastCalendarEntries() {
+            SettingsStore.Calendar profile = Settings.Profile.InPlay();
+            List<Event> pastEvents = GetCalendarEntriesInRange(new System.DateTime(1970, 1, 1), profile.SyncStart, true);
+            //Recurring masters/exceptions can have a first-occurrence date long in the past, yet still be an active series with future occurrences.
+            List<Event> toRemove = new List<Event>();
+            foreach (Event ev in pastEvents) {
+                if (!String.IsNullOrEmpty(ev.RecurringEventId)) continue; //Exception instance - handled via its own master.
+                if (ev.Recurrence == null) {
+                    //Single event - safe to consider "finished" based on its own date.
+                    toRemove.Add(ev);
+                } else if (recurringSeriesHasEnded(ev, profile.SyncStart)) {
+                    //Series is bounded and has fully finished - safe to remove entirely.
+                    toRemove.Add(ev);
+                }
+                //A still-active series is left alone: purging its past occurrences individually would generate
+                //a potentially huge list of recurrence exceptions and slow down every subsequent sync.
+            }
+            //Only ever purge items OGCS has synced (ie carry OGCS's own IDs). If OGCS has never touched an item, it must not delete it either.
+            return toRemove.Where(ev => CustomProperty.ExistAnyOutlookIDs(ev)).ToList();
+        }
+
+        /// <summary>Whether a recurring series is bounded by a RRULE UNTIL date that has already passed.</summary>
+        private static Boolean recurringSeriesHasEnded(Event ev, System.DateTime syncStart) {
+            Dictionary<String, String> rules = Recurrence.ExplodeRrule(ev.Recurrence);
+            if (rules == null || !rules.ContainsKey("UNTIL")) return false; //Open-ended, or COUNT-bounded - can't safely determine an end date.
+            try {
+                System.DateTime endDate = Recurrence.EndDate(rules["UNTIL"], ev.End.TimeZone);
+                return endDate < syncStart;
+            } catch (System.Exception ex) {
+                ex.Analyse("Failed to determine whether recurring series has ended.");
+                return false; //If in doubt, leave it alone.
+            }
+        }
+
         /// <summary>Get calendar Events occurring between the specified dates</summary>
         /// <returns>Single events, recurring master and exceptions</returns>
         public List<Event> GetCalendarEntriesInRange(System.DateTime from, System.DateTime to, Boolean suppressAdvisories = false, String recurringId = null) {

--- a/src/OutlookGoogleCalendarSync/Outlook/OutlookCalendar.cs
+++ b/src/OutlookGoogleCalendarSync/Outlook/OutlookCalendar.cs
@@ -109,10 +109,11 @@ namespace OutlookGoogleCalendarSync.Outlook {
         /// </summary>
         /// <param name="suppressAdvisories">Don't give user feedback, eg during background Push sync</param>
         /// <returns></returns>
-        public List<AppointmentItem> GetCalendarEntriesInRange(SettingsStore.Calendar profile, Boolean suppressAdvisories) {
+        public List<AppointmentItem> GetCalendarEntriesInRange(SettingsStore.Calendar profile, Boolean suppressAdvisories,
+            System.DateTime? overrideMin = null, System.DateTime? overrideMax = null) {
             List<AppointmentItem> filtered = new List<AppointmentItem>();
             try {
-                filtered = FilterCalendarEntries(profile, suppressAdvisories: suppressAdvisories);
+                filtered = FilterCalendarEntries(profile, suppressAdvisories: suppressAdvisories, overrideMin: overrideMin, overrideMax: overrideMax);
             } catch (System.Runtime.InteropServices.InvalidComObjectException ex) {
                 if (Outlook.Errors.HandleComError(ex) == Outlook.Errors.ErrorType.ObjectSeparatedFromRcw) {
                     try { Outlook.Calendar.Instance.Reset(); } catch { }
@@ -138,7 +139,7 @@ namespace OutlookGoogleCalendarSync.Outlook {
             } catch (System.ArgumentNullException ex) {
                 ex.LogAsFail().Analyse("It seems that Outlook has just been closed.");
                 Outlook.Calendar.Instance.Reset();
-                filtered = FilterCalendarEntries(profile, suppressAdvisories: suppressAdvisories);
+                filtered = FilterCalendarEntries(profile, suppressAdvisories: suppressAdvisories, overrideMin: overrideMin, overrideMax: overrideMax);
 
             } catch (System.Exception) {
                 if (!suppressAdvisories) Forms.Main.Instance.Console.Update("Unable to access the Outlook calendar.", Console.Markup.error);
@@ -147,7 +148,44 @@ namespace OutlookGoogleCalendarSync.Outlook {
             return filtered;
         }
 
-        public List<AppointmentItem> FilterCalendarEntries(SettingsStore.Calendar profile, Boolean filterBySettings = true, Boolean suppressAdvisories = false) {
+        /// <summary>Get calendar items that have fallen before the "days in the past" sync window, so are no longer touched by a normal sync</summary>
+        public List<AppointmentItem> GetPastCalendarEntries(SettingsStore.Calendar profile) {
+            List<AppointmentItem> pastEntries = GetCalendarEntriesInRange(profile, true, overrideMin: new System.DateTime(1970, 1, 1), overrideMax: profile.SyncStart);
+            //A recurring master's Start reflects its first occurrence, which can be long in the past for an otherwise still-active series.
+            List<AppointmentItem> toRemove = new List<AppointmentItem>();
+            foreach (AppointmentItem ai in pastEntries) {
+                if (!ai.IsRecurring) {
+                    //Single event - safe to consider "finished" based on its own date.
+                    toRemove.Add(ai);
+                } else if (recurringSeriesHasEnded(ai, profile)) {
+                    //Series is bounded and has fully finished - safe to remove entirely.
+                    toRemove.Add(ai);
+                }
+                //A still-active series is left alone: purging its past occurrences individually would create
+                //a recurrence exception per occurrence against the master, which Classic Outlook can only
+                //enumerate one-by-one - a noticeable performance hit on every subsequent sync.
+            }
+            //Only ever purge items OGCS has synced (ie carry OGCS's own IDs). If OGCS has never touched an item, it must not delete it either.
+            return toRemove.Where(x => CustomProperty.ExistAnyGoogleIDs(x, profile)).ToList();
+        }
+
+        /// <summary>Whether a recurring series is bounded by an end date that has already passed.</summary>
+        private static Boolean recurringSeriesHasEnded(AppointmentItem ai, SettingsStore.Calendar profile) {
+            if (ai.RecurrenceState != OlRecurrenceState.olApptMaster) return false; //Leave exception instances alone.
+            RecurrencePattern oPattern = null;
+            try {
+                oPattern = ai.GetRecurrencePattern();
+                return !oPattern.NoEndDate && oPattern.PatternEndDate < profile.SyncStart;
+            } catch (System.Exception ex) {
+                ex.Analyse("Failed to determine whether recurring series has ended.");
+                return false; //If in doubt, leave it alone.
+            } finally {
+                oPattern = (RecurrencePattern)ReleaseObject(oPattern);
+            }
+        }
+
+        public List<AppointmentItem> FilterCalendarEntries(SettingsStore.Calendar profile, Boolean filterBySettings = true, Boolean suppressAdvisories = false,
+            System.DateTime? overrideMin = null, System.DateTime? overrideMax = null) {
             //Filtering info @ https://msdn.microsoft.com/en-us/library/cc513841%28v=office.12%29.aspx
 
             List<AppointmentItem> result = new List<AppointmentItem>();
@@ -171,10 +209,8 @@ namespace OutlookGoogleCalendarSync.Outlook {
                 OutlookItems.Sort("[Start]", Type.Missing);
                 OutlookItems.IncludeRecurrences = false;
 
-                System.DateTime min = System.DateTime.MinValue;
-                System.DateTime max = System.DateTime.MaxValue;
-                min = profile.SyncStart;
-                max = profile.SyncEnd;
+                System.DateTime min = overrideMin ?? profile.SyncStart;
+                System.DateTime max = overrideMax ?? profile.SyncEnd;
 
                 string filter = "[End] >= '" + min.ToString(profile.OutlookDateFormat) +
                     "' AND [Start] < '" + max.ToString(profile.OutlookDateFormat) + "'";

--- a/src/OutlookGoogleCalendarSync/SettingsStore/Calendar.cs
+++ b/src/OutlookGoogleCalendarSync/SettingsStore/Calendar.cs
@@ -57,6 +57,7 @@ namespace OutlookGoogleCalendarSync.SettingsStore {
             MergeItems = true;
             DisableDelete = true;
             ConfirmOnDelete = true;
+            RemovePastEvents = false;
             TargetCalendar = Sync.Direction.OutlookToGoogle;
             CreatedItemsOnly = true;
             SetEntriesPrivate = false;
@@ -144,6 +145,8 @@ namespace OutlookGoogleCalendarSync.SettingsStore {
         [DataMember] public bool MergeItems { get; set; }
         [DataMember] public bool DisableDelete { get; set; }
         [DataMember] public bool ConfirmOnDelete { get; set; }
+        /// <summary>Remove OGCS-synced events from the destination calendar that have fallen outside the "days in the past" sync window.</summary>
+        [DataMember] public bool RemovePastEvents { get; set; }
         [DataMember] public Obfuscate Obfuscation { get; set; }
         [DataMember] public Sync.Direction TargetCalendar { get; set; }
         [DataMember] public Boolean CreatedItemsOnly { get; set; }
@@ -297,6 +300,7 @@ namespace OutlookGoogleCalendarSync.SettingsStore {
                 log.Info("  MergeItems: " + MergeItems);
                 log.Info("  DisableDelete: " + DisableDelete);
                 log.Info("  ConfirmOnDelete: " + ConfirmOnDelete);
+                log.Info("  RemovePastEvents: " + RemovePastEvents);
                 log.Info("  SetEntriesPrivate: " + SetEntriesPrivate + (SetEntriesPrivate ? "; " + PrivacyLevel : ""));
                 log.Info("  SetEntriesAvailable: " + SetEntriesAvailable + (SetEntriesAvailable ? "; " + AvailabilityStatus : ""));
                 log.Info("  SetEntriesColour: " + SetEntriesColour + (SetEntriesColour ? "; " + SetEntriesColourValue + "; \"" + SetEntriesColourName + "\"" : ""));

--- a/src/OutlookGoogleCalendarSync/Sync/Calendar.cs
+++ b/src/OutlookGoogleCalendarSync/Sync/Calendar.cs
@@ -623,6 +623,16 @@ namespace OutlookGoogleCalendarSync.Sync {
                     }
                 }
 
+                //Only for one-way profiles: in a Bidirectional sync the same "past" removal would be evaluated on both
+                //sides, making the outcome hard to reason about, so the feature is gated to a single sync direction.
+                if (!this.Profile.DisableDelete && this.Profile.RemovePastEvents && this.Profile.SyncDirection.Id != Sync.Direction.Bidirectional.Id) {
+                    List<Event> pastGoogleEntries = Ogcs.Google.Calendar.Instance.GetPastCalendarEntries();
+                    if (pastGoogleEntries.Count > 0) {
+                        console.Update(pastGoogleEntries.Count + " past Google calendar entries also flagged for removal.", Console.Markup.info);
+                        googleEntriesToBeDeleted.AddRange(pastGoogleEntries);
+                    }
+                }
+
                 int entriesUpdated = 0;
                 try {
                     #region Delete Google Entries
@@ -728,6 +738,15 @@ namespace OutlookGoogleCalendarSync.Sync {
                             Outlook.Calendar.ReleaseObject(outlookEntriesToBeDeleted.Last());
                             outlookEntriesToBeDeleted.Remove(outlookEntriesToBeDeleted.Last());
                         }
+                    }
+                }
+
+                //Only for one-way profiles - see matching note in the Google deletion block above.
+                if (!this.Profile.DisableDelete && this.Profile.RemovePastEvents && this.Profile.SyncDirection.Id != Sync.Direction.Bidirectional.Id) {
+                    List<AppointmentItem> pastOutlookEntries = Outlook.Calendar.Instance.GetPastCalendarEntries(this.Profile);
+                    if (pastOutlookEntries.Count > 0) {
+                        console.Update(pastOutlookEntries.Count + " past Outlook calendar entries also flagged for removal.", Console.Markup.info);
+                        outlookEntriesToBeDeleted.AddRange(pastOutlookEntries);
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Adds a "Remove past events" checkbox to the sync settings, with a sub-option to only remove events that OGCS itself created (on by default).
- When enabled, on each sync OGCS also cleans up destination-calendar events that have aged out of the "Days in the past" window — these currently fall out of scope of a normal sync entirely and are never revisited, so they otherwise accumulate on the destination calendar forever.
- Reuses the existing "Days in the past" setting as the age threshold, rather than adding a second date control.
- Respects "Disable deletions" and the existing mass-deletion confirmation prompt — no new deletion pathway, it just adds candidates into the same delete list used by a normal sync.
- Recurring series are handled carefully, since a recurring master's `Start` reflects only its *first* occurrence and can't be judged "finished" from that date alone:
  - A series that has actually ended (bounded by a UNTIL/end date that has passed) is removed in full, same as a single event.
  - A still-active series (open-ended, or its bounded end date hasn't arrived yet) is left alone at the master level — but any individual occurrence that has itself fallen before the sync window is removed on its own, without touching the series or its future occurrences. Outlook: walks day-by-day from the series' own start using the existing robust occurrence-lookup helper (the same one already used for matching Google exceptions, so moved/deleted occurrences are handled the same way elsewhere in the codebase). Google: uses the `events.instances()` endpoint bounded to the past window.
  - Series bounded only by an occurrence `COUNT` (no explicit end date) are left alone — not enough information to safely determine when they end without full RRULE expansion.

Addresses #1140.

## Test plan
- Manually verified: set "Days in the past" to a wider window, synced to create several test events on the destination calendar, then narrowed it back down and re-synced — the now-out-of-window events were correctly removed.
- Verified "Disable deletions" continues to suppress this cleanup entirely, and "Only if created by OGCS" correctly restricts/expands the candidate set.
- Verified a currently-active recurring series (started well outside the "days in the past" window but still recurring) is left untouched at the master/future-occurrence level.
- Verified end-to-end against a real calendar: past occurrences of an active recurring series were correctly removed while the series and its future occurrences remained intact.
- No automated test project exists in this repo to extend; verification was manual sync runs (Outlook<->Google) as noted above.