### PR TITLE
Handle inaccessible ResponseStatus without crashing the sync

### DIFF
--- a/src/OutlookGoogleCalendarSync/Outlook/OutlookCalendar.cs
+++ b/src/OutlookGoogleCalendarSync/Outlook/OutlookCalendar.cs
@@ -320,8 +320,14 @@ namespace OutlookGoogleCalendarSync.Outlook {
                             //Invitation
                             if (profile.OnlyRespondedInvites) {
                                 //These are actually filtered out later on when identifying differences
-                                if (filtered = ai.ResponseStatus == OlResponseStatus.olResponseNotResponded)
-                                    responseFiltered++;
+                                try {
+                                    if (filtered = ai.ResponseStatus == OlResponseStatus.olResponseNotResponded)
+                                        responseFiltered++;
+                                } catch (System.Runtime.InteropServices.COMException ex) {
+                                    if (ex.TargetSite.Name == "get_ResponseStatus") {
+                                        log.Warn("Could not access ResponseStatus property for " + GetEventSummary(ai));
+                                    } else throw;
+                                }
                             }
                         } finally {
                             if (filtered && profile.SyncDirection.Id == Sync.Direction.Bidirectional.Id && CustomProperty.ExistAnyGoogleIDs(ai, profile)) {
@@ -1692,9 +1698,15 @@ namespace OutlookGoogleCalendarSync.Outlook {
                 //Check if items to be deleted have invitations not responded to
                 int responseFiltered = 0;
                 for (int o = outlook.Count - 1; o >= 0; o--) {
-                    if (outlook[o].ResponseStatus == OlResponseStatus.olResponseNotResponded) {
-                        outlook.Remove(outlook[o]);
-                        responseFiltered++;
+                    try {
+                        if (outlook[o].ResponseStatus == OlResponseStatus.olResponseNotResponded) {
+                            outlook.Remove(outlook[o]);
+                            responseFiltered++;
+                        }
+                    } catch (System.Runtime.InteropServices.COMException ex) {
+                        if (ex.TargetSite.Name == "get_ResponseStatus") {
+                            log.Warn("Could not access ResponseStatus property for " + GetEventSummary(outlook[o]));
+                        } else throw;
                     }
                 }
                 if (responseFiltered > 0) log.Info(responseFiltered + " Outlook items will not be deleted due to only syncing invites that have been responded to.");


### PR DESCRIPTION
## Summary
- `AppointmentItem.ResponseStatus` can throw a `COMException` for certain items ("Sorry, something went wrong. You may want to try again.", per the original report on #972).
- With "Only sync invites I've responded to" enabled, this was accessed unguarded at two call sites in `Outlook/OutlookCalendar.cs`:
  - `FilterCalendarEntries` (deciding whether to include an item when building the sync set)
  - `IdentifyEventDifferences` (deciding whether to spare an unresponded-invite item from deletion)
- Either one throwing aborted the *entire* sync rather than just skipping the filter for that one item.
- This adds the same defensive `COMException` handling already used for the `Categories` property a few lines above the first call site — logs a warning and treats the item as if it passed the filter, consistent with how other fragile Outlook COM property reads are already handled elsewhere in this file.

Fixes #972.

## Test plan
- Verified the change compiles and the rest of the invite-filtering logic (categories, availability, subject, all-day exclusions) is untouched.
- Could not reproduce the original corrupted-item COM error locally (it's item-specific per the original report), so this hasn't been exercised against a live repro — happy to have it verified against the original reporter's environment if still around, or treat this as defensive hardening consistent with the existing pattern either way.