### PR TITLE
Handle inaccessible custom UserProperty without crashing item processing

### DIFF
--- a/src/OutlookGoogleCalendarSync/Outlook/CustomProperty.cs
+++ b/src/OutlookGoogleCalendarSync/Outlook/CustomProperty.cs
@@ -153,6 +153,9 @@ namespace OutlookGoogleCalendarSync.Outlook {
                             propertyName = up.Name;
                             calendarKeys.Add(up.Name, up.Value.ToString());
                         }
+                    } catch (System.Runtime.InteropServices.COMException ex) {
+                        //Eg "The object does not support this method." - some legacy/incompatible custom properties can't be read.
+                        log.Warn("Could not access custom property " + (propertyName ?? "#" + p) + " for " + Calendar.GetEventSummary(ai) + " - " + ex.Message);
                     } finally {
                         up = (UserProperty)Calendar.ReleaseObject(up);
                     }


### PR DESCRIPTION
## Summary
- `UserProperty.Value` (and potentially `.Name`) can throw a `COMException` - "The object does not support this method." - for certain legacy/incompatible custom properties on an Outlook item. The original report (#1178) hit this on a recurring appointment's exception instance.
- This was unguarded inside `getKeySet()` in `Outlook/CustomProperty.cs`, so one unreadable custom property on one item aborted OGCS's whole ID/metadata lookup for that item (and, per the original stack trace, could bubble up and abort processing of that item's comparison pass entirely) rather than just being skipped.
- Adds a `catch` for `COMException` around the per-property read, logging a warning and continuing on to the next property - consistent with how other fragile Outlook COM property reads are handled elsewhere in the codebase (see `Categories` handling in `OutlookCalendar.cs`, and PR #2357 for a similar fix).
- The existing `ArgumentException` handling (for the unrelated duplicate-key case, #2233) is untouched.

Fixes #1178.

## Test plan
- Verified the change compiles; the rest of the key-set resolution logic (used for matching an item's custom properties to a specific Outlook calendar) is unchanged.
- Could not reproduce the specific problematic property from the original report locally (it was tied to a since-modified recurring series on the reporter's end), so this hasn't been exercised against a live repro - it directly addresses the exact COM exception and call path from the reported stack trace, but flagging in case a maintainer wants to verify against a similarly-affected item before merging.