### PR TITLE
Don't show the modal retry prompt for transient network failures

### DIFF
--- a/src/OutlookGoogleCalendarSync/Extensions/Exception.cs
+++ b/src/OutlookGoogleCalendarSync/Extensions/Exception.cs
@@ -130,6 +130,24 @@ namespace OutlookGoogleCalendarSync {
             if (throwError) throw ex;
         }
 
+        /// <summary>
+        /// Whether this exception (or any exception in its chain) represents a transient network
+        /// connectivity problem - eg no internet, DNS failure, connection reset, timeout - as opposed
+        /// to a genuine application/configuration error that a user needs to look at.
+        /// </summary>
+        public static Boolean IsTransientNetworkError(this System.Exception ex) {
+            if (ex is AggregateException aex && aex.InnerException != null)
+                return IsTransientNetworkError(aex.InnerException);
+            if (ex is System.Net.Sockets.SocketException ||
+                ex is System.Net.WebException ||
+                ex is System.Net.Http.HttpRequestException ||
+                ex is System.Threading.Tasks.TaskCanceledException) //Typically a network timeout, not user cancellation - that's handled separately via CancellationPending.
+                return true;
+            if (ex.InnerException != null)
+                return IsTransientNetworkError(ex.InnerException);
+            return false;
+        }
+
         public static String FriendlyMessage(this System.Exception ex) {
             if (ex is global::Google.GoogleApiException gaex) {
                 if (gaex.Error != null)

--- a/src/OutlookGoogleCalendarSync/Sync/Calendar.cs
+++ b/src/OutlookGoogleCalendarSync/Sync/Calendar.cs
@@ -169,6 +169,14 @@ namespace OutlookGoogleCalendarSync.Sync {
                                             mainFrm.Console.Update(ex.Message, Console.Markup.fail, newLine: false);
                                             syncResult = SyncResult.ReconnectThenRetry;
 
+                                        } else if (ex.IsTransientNetworkError()) {
+                                            //Eg no internet, DNS failure, connection reset, timeout - don't interrupt the user with a
+                                            //modal "try again?" prompt for what's likely a temporary connectivity blip (#1150) - just
+                                            //log it and let the next scheduled sync retry automatically, same as other known-transient errors.
+                                            Ogcs.Exception.Analyse(Ogcs.Exception.LogAsFail(ex));
+                                            mainFrm.Console.Update("A network connectivity problem was encountered.<br/>Will retry at the next scheduled sync.", Console.Markup.fail, notifyBubble: true);
+                                            syncResult = SyncResult.AutoRetry;
+
                                         } else {
                                             Ogcs.Exception.Analyse(ex, true);
                                             mainFrm.Console.UpdateWithError(null, ex, notifyBubble: true);


### PR DESCRIPTION
## Summary

Diagnosed from a real crash dump analysis of a hung OGCS process: a background sync thread hit a `WebException` ("underlying connection was closed") from a Google API call and was blocked trying to marshal an error report onto the UI thread, while the UI thread was itself blocked showing a *different* modal dialog triggered moments earlier by another background thread - the app appeared completely frozen until that buried dialog was found and dismissed.

Digging into `Sync/Calendar.cs`, there's already a `SyncResult.AutoRetry` classification used for specific known-transient errors (e.g. the Exchange "network problems" COM error, and one particular HTTP connection-reset HResult) - these are logged and reported via a non-blocking tray notification, and the *next scheduled sync* just quietly retries. No dialog involved.

Generic connectivity failures (no internet, DNS failure, connection reset, timeout) weren't covered by that classification, so they fall through to the catch-all path, which shows a blocking `"Sync Failed - Do you want to try again?"` dialog on the next failed attempt (`Sync/Calendar.cs:103`). For anyone on an intermittent connection - VPN without a configured proxy, a flaky network, etc. - with a frequent sync interval, this means a recurring modal dialog every cycle until connectivity returns, exactly the scenario reported in #1150 (open since 2021, several hotfixes over the years for specific triggers, but the general pattern was never addressed).

## Change

- Adds `Exception.IsTransientNetworkError()` (`Extensions/Exception.cs`) - walks the exception chain (including one level of `AggregateException` unwrapping) checking for `SocketException`, `WebException`, `HttpRequestException`, or `TaskCanceledException`.
- In `Sync/Calendar.cs`'s sync-failure catch-all, checks this before defaulting to `SyncResult.Fail`, routing transient network errors into the existing `AutoRetry` path instead - same treatment as the other known-transient cases already handled there, just widened to cover the general case rather than a couple of specific HResults.
- Genuinely unexpected/unclassified errors still hit the existing modal prompt - this doesn't remove that safety net, just stops it firing for ordinary connectivity blips.

No new settings, no architecture change - reuses the exact mechanism already established in this file.

## Test plan

- Verified the change compiles cleanly.
- Could not reproduce the original "two dialogs stacked" scenario live (it's timing-dependent on two failures landing close together), but the fix addresses the root cause identified from the dump: routing this whole class of exception away from the modal-dialog path entirely, rather than trying to prevent dialogs from stacking after the fact.
- Verified `TaskCanceledException` here is distinct from user-initiated cancellation, which this codebase handles separately via `CancellationPending` checks and `SyncResult.UserCancelled`, not exceptions - so this shouldn't misclassify a deliberate cancel as a network retry.