### PR TITLE
Add option to suppress classic Outlook's own reminder popups

### DIFF
--- a/src/OutlookGoogleCalendarSync/Forms/MainForm.Designer.cs
+++ b/src/OutlookGoogleCalendarSync/Forms/MainForm.Designer.cs
@@ -277,6 +277,7 @@
             this.cbShowSystemNotifications = new System.Windows.Forms.CheckBox();
             this.cbMinimiseToTray = new System.Windows.Forms.CheckBox();
             this.cbStartInTray = new System.Windows.Forms.CheckBox();
+            this.cbSuppressOutlookReminders = new System.Windows.Forms.CheckBox();
             this.cbStartOnStartup = new System.Windows.Forms.CheckBox();
             this.lSettingInfo = new System.Windows.Forms.Label();
             this.bSave = new OutlookGoogleCalendarSync.Extensions.MenuButton();
@@ -2982,6 +2983,7 @@
             this.tabAppBehaviour.Controls.Add(this.cbShowSystemNotifications);
             this.tabAppBehaviour.Controls.Add(this.cbMinimiseToTray);
             this.tabAppBehaviour.Controls.Add(this.cbStartInTray);
+            this.tabAppBehaviour.Controls.Add(this.cbSuppressOutlookReminders);
             this.tabAppBehaviour.Controls.Add(this.cbStartOnStartup);
             this.tabAppBehaviour.Location = new System.Drawing.Point(4, 24);
             this.tabAppBehaviour.Name = "tabAppBehaviour";
@@ -3473,7 +3475,18 @@
             this.cbStartInTray.Text = "Start in tray";
             this.cbStartInTray.UseVisualStyleBackColor = true;
             this.cbStartInTray.CheckedChanged += new System.EventHandler(this.cbStartInTrayCheckedChanged);
-            // 
+            //
+            // cbSuppressOutlookReminders
+            //
+            this.cbSuppressOutlookReminders.AutoSize = true;
+            this.cbSuppressOutlookReminders.Location = new System.Drawing.Point(185, 53);
+            this.cbSuppressOutlookReminders.Name = "cbSuppressOutlookReminders";
+            this.cbSuppressOutlookReminders.Size = new System.Drawing.Size(224, 17);
+            this.cbSuppressOutlookReminders.TabIndex = 42;
+            this.cbSuppressOutlookReminders.Text = "Suppress classic Outlook\'s own reminders";
+            this.cbSuppressOutlookReminders.UseVisualStyleBackColor = true;
+            this.cbSuppressOutlookReminders.CheckedChanged += new System.EventHandler(this.cbSuppressOutlookReminders_CheckedChanged);
+            //
             // cbStartOnStartup
             // 
             this.cbStartOnStartup.AutoSize = true;
@@ -4606,6 +4619,7 @@
         private System.Windows.Forms.CheckBox cbShowSystemNotificationsIfChange;
         private System.Windows.Forms.CheckBox cbMinimiseToTray;
         private System.Windows.Forms.CheckBox cbStartInTray;
+        private System.Windows.Forms.CheckBox cbSuppressOutlookReminders;
         private System.Windows.Forms.CheckBox cbStartOnStartup;
         private System.Windows.Forms.Label txtProfileLoading;
         private System.Windows.Forms.Panel panelProfileLoading;

--- a/src/OutlookGoogleCalendarSync/Forms/MainForm.cs
+++ b/src/OutlookGoogleCalendarSync/Forms/MainForm.cs
@@ -228,6 +228,7 @@ namespace OutlookGoogleCalendarSync.Forms {
             cbHideSplash.Checked = Settings.Instance.HideSplashScreen ?? false;
             cbSuppressSocialPopup.Checked = Settings.Instance.SuppressSocialPopup;
             cbStartInTray.Checked = Settings.Instance.StartInTray;
+            cbSuppressOutlookReminders.Checked = Settings.Instance.SuppressOutlookReminders;
             cbMinimiseToTray.Checked = Settings.Instance.MinimiseToTray;
             cbMinimiseNotClose.Checked = Settings.Instance.MinimiseNotClose;
             cbPortable.Checked = Settings.Instance.Portable && !Program.IsInstalled;
@@ -2688,6 +2689,12 @@ namespace OutlookGoogleCalendarSync.Forms {
 
         private void cbStartInTrayCheckedChanged(object sender, System.EventArgs e) {
             Settings.Instance.StartInTray = cbStartInTray.Checked;
+        }
+
+        private void cbSuppressOutlookReminders_CheckedChanged(object sender, System.EventArgs e) {
+            Settings.Instance.SuppressOutlookReminders = cbSuppressOutlookReminders.Checked;
+            Ogcs.Extensions.MessageBox.Show("This takes effect the next time OGCS connects to Outlook (eg on next sync, or after restarting OGCS).",
+                "Restart required", System.Windows.Forms.MessageBoxButtons.OK, System.Windows.Forms.MessageBoxIcon.Information);
         }
 
         private void cbMinimiseToTrayCheckedChanged(object sender, System.EventArgs e) {

--- a/src/OutlookGoogleCalendarSync/Outlook.Factory/OutlookNew.cs
+++ b/src/OutlookGoogleCalendarSync/Outlook.Factory/OutlookNew.cs
@@ -14,6 +14,7 @@ namespace OutlookGoogleCalendarSync.Outlook {
 
         private Microsoft.Office.Interop.Outlook.Application oApp;
         private ExplorerWatcher explorerWatcher;
+        private ReminderWatcher reminderWatcher;
         private String currentUserSMTP;  //SMTP of account owner that has Outlook open
         private String currentUserName;  //Name of account owner - used to determine if attendee is "self"
         private Folders folders;
@@ -92,6 +93,7 @@ namespace OutlookGoogleCalendarSync.Outlook {
 
                 //Set up event handlers
                 explorerWatcher = new ExplorerWatcher(oApp);
+                if (Settings.Instance.SuppressOutlookReminders) reminderWatcher = new ReminderWatcher(oApp);
 
             } catch (System.Runtime.InteropServices.COMException ex) {
                 if (ex.GetErrorCode(0x0000FFFF) == "0x00000009") { //Cannot complete the operation. You are not connected. [Issue #514, occurs on GetNamespace("mapi")]
@@ -120,6 +122,8 @@ namespace OutlookGoogleCalendarSync.Outlook {
                     calendarFolders = new Dictionary<string, OutlookCalendarListEntry>();
                     Calendar.Categories?.Dispose();
                     explorerWatcher = (ExplorerWatcher)Calendar.ReleaseObject(explorerWatcher);
+                    reminderWatcher?.Dispose();
+                    reminderWatcher = null;
                 } catch (System.Exception ex) {
                     log.Debug(ex.Message);
                 }

--- a/src/OutlookGoogleCalendarSync/Outlook/ReminderWatcher.cs
+++ b/src/OutlookGoogleCalendarSync/Outlook/ReminderWatcher.cs
@@ -1,0 +1,44 @@
+using Ogcs = OutlookGoogleCalendarSync;
+using log4net;
+using Microsoft.Office.Interop.Outlook;
+
+namespace OutlookGoogleCalendarSync.Outlook {
+    /// <summary>
+    /// Hides classic Outlook's own native reminder popups. Intended for when this Outlook
+    /// instance is only being used in the background for OGCS's calendar automation, while
+    /// the user's actual day-to-day client (eg "New Outlook") shows its own reminders for the
+    /// same mailbox - without this, both clients independently pop a reminder for the same item.
+    /// Cancels the popup via Reminders.BeforeReminderShow; never calls Dismiss()/Snooze()/Remove(),
+    /// so nothing is written back to the mailbox and no other client's reminders are affected.
+    /// </summary>
+    class ReminderWatcher {
+        private static readonly ILog log = LogManager.GetLogger(typeof(ReminderWatcher));
+
+        private Reminders reminders;
+
+        public ReminderWatcher(Application oApp) {
+            Reminders reminders = null;
+            try {
+                reminders = oApp.Reminders;
+                log.Info("Suppressing classic Outlook's own reminder popups, per configuration.");
+
+                this.reminders = reminders;
+                this.reminders.BeforeReminderShow += new ReminderCollectionEvents_BeforeReminderShowEventHandler(reminders_BeforeReminderShow);
+            } catch (System.Exception ex) {
+                ex.Analyse("Failed to set up Outlook reminder suppression.");
+            }
+        }
+
+        private void reminders_BeforeReminderShow(ref bool Cancel) {
+            log.Fine("Suppressing a native Outlook reminder popup.");
+            Cancel = true;
+        }
+
+        public void Dispose() {
+            if (reminders != null) {
+                try { reminders.BeforeReminderShow -= reminders_BeforeReminderShow; } catch { }
+                reminders = (Reminders)Calendar.ReleaseObject(reminders);
+            }
+        }
+    }
+}

--- a/src/OutlookGoogleCalendarSync/OutlookGoogleCalendarSync.csproj
+++ b/src/OutlookGoogleCalendarSync/OutlookGoogleCalendarSync.csproj
@@ -683,6 +683,7 @@
     <Compile Include="Outlook.Graph\O365Recurrence.cs" />
     <Compile Include="Outlook\CustomProperty.cs" />
     <Compile Include="Outlook\ExplorerWatcher.cs" />
+    <Compile Include="Outlook\ReminderWatcher.cs" />
     <Compile Include="Outlook\GMeet.cs" />
     <Compile Include="Outlook\OutlookRecurrence.cs" />
     <Compile Include="Outlook\OutlookCalendar.cs" />

--- a/src/OutlookGoogleCalendarSync/SettingsStore/Settings.cs
+++ b/src/OutlookGoogleCalendarSync/SettingsStore/Settings.cs
@@ -83,6 +83,7 @@ namespace OutlookGoogleCalendarSync {
             PersonalClientIdentifier = "";
             PersonalClientSecret = "";
             DisconnectOutlookBetweenSync = false;
+            SuppressOutlookReminders = false;
             TimezoneMaps = new TimezoneMappingDictionary();
 
             apiLimit_inEffect = false;
@@ -151,6 +152,8 @@ namespace OutlookGoogleCalendarSync {
             }
         }
         [DataMember] public Boolean DisconnectOutlookBetweenSync { get; set; }
+        /// <summary>Hide classic Outlook's own native reminder popups, eg when it's only running in the background for OGCS automation while "New Outlook" is used day-to-day.</summary>
+        [DataMember] public Boolean SuppressOutlookReminders { get; set; }
         [DataMember] public TimezoneMappingDictionary TimezoneMaps { get; private set; }
         [CollectionDataContract(
             ItemName = "TimeZoneMap",
@@ -433,6 +436,7 @@ namespace OutlookGoogleCalendarSync {
             log.Info(Program.MaskFilePath(ConfigFile));
             log.Info("OUTLOOK SETTINGS:-");
             log.Info("  Disconnect Between Sync: " + DisconnectOutlookBetweenSync);
+            log.Info("  Suppress Outlook Reminders: " + SuppressOutlookReminders);
             if (TimezoneMaps.Count > 0) {
                 log.Info("  Custom Timezone Mapping:-");
                 TimezoneMaps.ToList().ForEach(tz => log.Info("    " + tz.Key + " => " + tz.Value));


### PR DESCRIPTION
## Summary

A user reported (not yet filed as an issue, raising it here directly) an increasingly common scenario as Microsoft pushes the "New Outlook" migration: they use New Outlook as their day-to-day client, but their org's Entra/Azure AD tenant blocks self-service consent for third-party Graph apps, so switching OGCS to the Microsoft 365/Graph sync path (as the app's own guidance for New Outlook suggests) isn't an option for them without admin approval they're unlikely to get.

That leaves them on the classic-Outlook-COM sync path, which is otherwise fine - except OGCS's classic-Outlook detection (`Outlook.Factory.checkForOutlookInstall()`) is based purely on whether `Outlook.Application` is COM-registered, not on which client the user actually has open. Since New Outlook is commonly installed *alongside* classic Outlook rather than replacing it, OGCS silently attaches to classic Outlook in the background for its automation - and that background instance runs its own full native reminder engine against the mailbox, completely independent of New Outlook's own reminders for the same items. Net effect: two reminder popups per meeting, one from each client.

## Change

- New opt-in setting `SuppressOutlookReminders` (Application Behaviour tab: "Suppress classic Outlook's own reminders"), off by default.
- New `Outlook/ReminderWatcher.cs`, following the exact pattern this codebase already uses for `ExplorerWatcher` (hook a COM event in `OutlookNew.Connect()`, release it in `Disconnect()`).
- Hooks `Outlook.Reminders.BeforeReminderShow` and sets `Cancel = true` to suppress the popup.

Deliberately **does not** call `Dismiss()`, `Snooze()`, or `Reminders.Remove()` - I verified via reflection against the actual `Microsoft.Office.Interop.Outlook.dll` in this repo's build output that `Reminder.IsVisible` is read-only in this PIA (my first attempt tried setting it directly; the compiler caught it), and I didn't want to reach for `Dismiss()`/`Snooze()` since those *do* write reminder state back to the item, which would very plausibly propagate to Exchange and suppress the reminder in New Outlook too - the opposite of what's wanted here. `BeforeReminderShow`'s `Cancel` flag only prevents the local popup; nothing is written back.

## Test plan

- Verified via reflection against the built `Microsoft.Office.Interop.Outlook.dll` that `_Reminder`/`_Reminders`/`ReminderCollectionEvents_BeforeReminderShowEventHandler` exist with the signatures used here, after an initial wrong guess (`Reminders.ReminderAdd` + `Reminder.IsVisible = false`) was caught by the compiler.
- Compiles cleanly (Debug, Any CPU).
- **Not tested against a live dual-Outlook (classic + New Outlook) environment** - I don't have one available. The mechanism (`BeforeReminderShow` cancellation) is a documented part of the Outlook object model and doesn't touch mailbox state, but I'd appreciate it being tried against the actual reported scenario before merging, or happy to have the approach questioned if there's a reason `BeforeReminderShow` behaves differently than I'd expect for a headless/background-attached Outlook instance specifically.